### PR TITLE
Bugfix Issue #6423 to check status, not existence of filter_autop

### DIFF
--- a/core/modules/field/modules/text/text.module
+++ b/core/modules/field/modules/text/text.module
@@ -462,8 +462,8 @@ function text_summary($text, $format_id = NULL, $size = 600) {
   // If no complete paragraph then treat line breaks as paragraphs.
   $line_breaks = array('<br />' => 6, '<br>' => 4);
   // Newline only indicates a line break if line break converter
-  // filter is present.
-  if (isset($format->filters['filter_autop'])) {
+  // filter is enabled.
+  if (isset($format->filters['filter_autop']) && ($format->filters['filter_autop']->status != 0)) {
     $line_breaks["\n"] = 1;
   }
   $break_points[] = $line_breaks;


### PR DESCRIPTION
Bugfix related to Issue #6423 text_summary returns empty string with filtered format Check status, not just existence of filter_autop

Fixes https://github.com/backdrop/backdrop-issues/issues/6423

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
